### PR TITLE
add details component for additional details route

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
 import DogList from './DogList';
+import DogDetails from './DogDetails';
 import {Switch, Route} from 'react-router-dom';
 import './App.css';
 import gadget from './img/gadget.jpg';
@@ -43,7 +44,19 @@ class App extends Component {
   };
 
   render() {
-    return <Route path="/home" render={() => <DogList dogs={this.props.dogs} />} />;
+    const getDog = props => {
+      let name = props.match.params.name;
+      let currentDog = this.props.dogs.find(
+        dog => dog.name.toLowerCase() === name.toLowerCase()
+      );
+      return <DogDetails {...props} dog={currentDog} />
+    }
+    return (
+      <Switch>
+        <Route exact path="/home" render={() => <DogList dogs={this.props.dogs} />} />;
+        <Route exact path="/home/:name" render={getDog} />;
+      </Switch>
+    );
   }
 }
 

--- a/src/DogDetails.js
+++ b/src/DogDetails.js
@@ -1,0 +1,13 @@
+import React, { Component } from 'react';
+
+class DogDetails extends Component {
+    render() {
+        return (
+            <div>
+                <h1>{this.props.dog.name}</h1>
+            </div>
+        )
+    }
+}
+
+export default DogDetails;


### PR DESCRIPTION
This creates a `DogDetails` component, and creates another route that is set up to take you to the specific details page.

A new file named `DogDetails.js` is created.  It is set up as a class-based component, and the `export` is set up at the bottom of the component.

In `App.js`, the `DogDetails` component is imported at the top of the code.  A route is now added to the `return` section, that is set up to accept a route `/home/:name`, where the name is a path variable that will change depending on the dog that is eventually selected.  Also, a `Switch` element is wrapped around the routes, and each of the routes have `exact` passed into them, so they only match the desired route.  To get the route to work properly, a function is defined at the top of the `render` section named `getDog`.  This function will accept some `props`.  Inside the function, a variable `name` is defined to equal the name extracted from the route.  Also, a variable `currentDog` is defined so that we find the current dog.  To do so, `.find` is used so that for each dog, the one we want `dog.name` is equal to `name` coming from the route.  Both sides of the equation are set to `toLowerCase`, to eliminate case-sensitive problems.  Then this is set to `return` a `DogDetails` component, that has the `props` passed in, as well as the `dog` prop set to equal `currentDog`.  
Now in the `return`, the path is updated so that the path with the name variable is set to `render` the `getDog` variable, which will provide the updated `DogDetails` component.
For now, inside the `DogDetails.js` file, it is set to simply return `this.props.dogs.name`, to check everything is being passed in and that a name will display for each route.