### PR TITLE
adds a link on each displayed name to take user to details route

### DIFF
--- a/src/DogList.js
+++ b/src/DogList.js
@@ -13,6 +13,7 @@
 // export default DogList;
 
 import React, { useState} from 'react';
+import { Link } from 'react-router-dom';
 import './DogList.css';
 
 function DogList(props) {
@@ -23,7 +24,7 @@ function DogList(props) {
                 {props.dogs.map(d => (
                     <div className="DogList-Dog col-md-4 text-center" key={d.name}>
                         <img src={d.src} alt={d.name} />
-                        <h3>{d.name}</h3>
+                        <Link to={`/home/${d.name}`}><h3>{d.name}</h3></Link>
                     </div>
                 ))}                
             </div>


### PR DESCRIPTION
This adds a link the user can click on for each detailed item, by adding a link to the name under the images.  
In the `DogDetails.js` file, at the top `Link` is imported from `react-router-dom`.  Then in the `return`, a `<Link>` element is wrapped around the `{d.name}`.  The `to` prop is then set to the proper route, by interpolating the path `/home/` followed by the dynamic path of `{d.name}`.  This will then take the user to the matching route for that name.