### PR TITLE
add overall styles to app

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Fun App</title>
+    <title>Fun Finder</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/DogDetails.css
+++ b/src/DogDetails.css
@@ -1,4 +1,13 @@
 .DogDetails-card {
     margin: auto;
     width: 75%;
+    box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.1)
+}
+  
+.DogDetails-card img {
+    filter: grayscale();
+    transition: 0.4s filter ease;
+}
+.DogDetails-card:hover img {
+    filter: none;
 }

--- a/src/DogDetails.js
+++ b/src/DogDetails.js
@@ -6,7 +6,7 @@ class DogDetails extends Component {
     render() {
         var { dog } = this.props;
         return (
-            <div className="DogDetails row justify-content-center mt-5">
+            <div className="DogDetails row justify-content-center my-5">
                 <div className="col-11 col-lg-5">
                     <div className="DogDetails-card card">
                         <img className="card-img-top" src={dog.src} alt={dog.name} />
@@ -22,7 +22,7 @@ class DogDetails extends Component {
                             ))}
                         </ul>
                         <div className="card-body">
-                                <Link to="/home" className="btn btn-info">Go Back</Link>                   
+                                <Link to="/home" className="btn btn-info">Go Back</Link>           
                         </div>
                     </div>
                 </div>

--- a/src/DogList.css
+++ b/src/DogList.css
@@ -1,3 +1,55 @@
+.DogList h1 {    
+    font-weight: 400;
+    color: firebrick;
+}
+
 .DogList-Dog img {
     width: 75%;
+    filter: grayscale();
+    border-radius: 50%;
+    box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.1);
+    transition: 0.4s filter ease;
 }
+
+.DogList-Dog:hover img {
+    filter: none;
+}
+
+.DogList-Name {
+    text-decoration: none;
+    border: 4px solid transparent;
+    display: inline-block;
+    vertical-align: top;
+    line-height: 36px;
+    text-transform: uppercase;
+    color: black;
+    letter-spacing: 0.2em;
+    text-align: center;
+    font-size: 1.4rem;
+    margin: 10px;
+    position: relative;
+}
+
+.DogList-Name:hover {
+    text-decoration: none;
+}
+
+.DogList-Name:after {
+    width: 0%;
+    height: 4px;
+    display: block;
+    background-color: #fff;
+    content: " ";
+    position: absolute;
+    top: 34px;
+    left: 50%;
+    transition: left 0.4s cubic-bezier(0.215, 0.61, 0.355, 1),
+      width 0.4s cubic-bezier(0.215, 0.61, 0.355, 1);
+}
+
+.DogList-Dog:hover .DogList-Name:after {
+    width: 100%;
+    top: 34px;
+    left: 0;
+}
+

--- a/src/DogList.js
+++ b/src/DogList.js
@@ -19,12 +19,12 @@ import './DogList.css';
 function DogList(props) {
     return (
         <div className="DogList">
-            <h1 className="display-1 text-center">Dog List!</h1>
+            <h1 className="display-1 text-center mt-3 mb-5">Fun Finder</h1>
             <div className="row">
                 {props.dogs.map(d => (
                     <div className="DogList-Dog col-md-4 text-center" key={d.name}>
-                        <img src={d.src} alt={d.name} />
-                        <Link to={`/home/${d.name}`}><h3>{d.name}</h3></Link>
+                        <Link to={`/home/${d.name}`}><img src={d.src} alt={d.name} /></Link>
+                        <Link className="DogList-Name mt-3" to={`/home/${d.name}`}><h3>{d.name}</h3></Link>
                     </div>
                 ))}                
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,15 @@
+@import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@200;400&display=swap');
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Source Sans Pro', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background: linear-gradient(
+    100deg,
+    rgba(250, 214, 195, 0.8) 30%,
+    #b0eae8 120%
+  );
 }
 
 code {


### PR DESCRIPTION
This adds overall styles to the app for several of the CSS files.  Also, the link to the details route is expanded to allow the user to click on the image, in addition to the name. The app name was adjusted as well, both in title and in browser tab.

In `DogDetails.css`, the details card was given a `box-shadow`.  The image is given a `grayscale` filter, which is set to not display when hovered over.  In the corresponding `DogDetails.js` file, the entire div is given a Bootstrap class to give it margin on top and bottom, instead of just top.

In `DogList.css`, the main heading is given a color of `firebrick`, as well as a font weight.  Just as with the Details image, the image here is given a `grayscale` filter, which is set to not display when hovered over. Also, a `box-shadow` is given here.  For the name, there are many styles provided to set its look, including uppercase, font size, and margin.  A pseudo element is given to then provide a hover effect that underlines the name, and makes the line expand from the middle outwards. This is accomplished by positioning the element, and providing a `transition` effect.  The width starts at 0 and expands to 100% when hovered over.  In the corresponding `DogList.js`, the title is changed to "Fun Finder".  Also, the `<Link>` coming from `react-router-dom` is now set to be around the image, the same as was done with the name.  This allows either to be clicked, taking the user to the Details route.  For the name, a Bootstrap class was given for some margin top above it.

In `index.css`, a Google font family is set to `import` at the top.  Then the `font-family` is set to `Source Sans Pro', sans-serif`.  The background is given a `linear-gradient` here, to set the background for the entire app, that gradually blends from one side to the other.

In the `index.html` file, the browser tab was renamed to "Fun Finder".

